### PR TITLE
Use bundler-first approach and integrate Biome in CI

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        command: [check-types, check-format, check-circular, lint, test]
+        command: [check-types, check-biome-ci, check-circular, test]
 
     name: ${{ matrix.command }}
 

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -5,12 +5,12 @@
   "type": "module",
   "scripts": {
     "check-types": "tsc --noEmit",
+    "check-biome": "biome check",
     "check-circular": "madge --circular --extensions ts ./src --ts-config ./tsconfig.json",
     "dev": "next dev",
     "build": "next build",
     "clean": "del-cli .next tsconfig.tsbuildinfo",
-    "start": "next start",
-    "lint": "biome check"
+    "start": "next start"
   },
   "dependencies": {
     "@radix-ui/react-icons": "^1.3.2",

--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -13,10 +13,5 @@
     "${configDir}/next-env.d.ts",
     "${configDir}/.next/types/**/*.ts",
     ".next/types/**/*.ts"
-  ],
-  "references": [
-    {
-      "path": "../../packages/common"
-    }
   ]
 }

--- a/package.json
+++ b/package.json
@@ -29,6 +29,8 @@
   },
   "scripts": {
     "check-types": "turbo check-types --continue",
+    "check-biome": "turbo check-biome --continue",
+    "check-biome-ci": "biome ci",
     "check-circular": "turbo check-circular --continue",
     "build": "turbo build",
     "build:fns": "turbo build --filter=@repo/fns",
@@ -37,12 +39,9 @@
     "dev": "turbo dev",
     "deploy": "firebase deploy",
     "watch": "turbo watch build --filter=@repo/core --filter=@repo/fns --filter=@repo/api",
-    "lint": "biome check",
-    "lint:fix": "biome check --write",
     "test": "turbo test -- --watch false",
-    "format": "biome format --write",
-    "check-format": "biome check",
     "emulate": "firebase emulators:start --project demo-mono-ts",
+    "format": "biome check --write",
     "db:get-indexes": "firebase firestore:indexes > firestore.indexes.json"
   },
   "devDependencies": {

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -14,11 +14,11 @@
   ],
   "scripts": {
     "check-types": "tsc --noEmit",
+    "check-biome": "biome check",
     "check-circular": "madge --circular --extensions ts ./src --ts-config ./tsconfig.json",
     "test": "vitest",
     "build": "bunchee --sourcemap --target es2022",
     "clean": "del-cli dist tsconfig.tsbuildinfo",
-    "lint": "biome check",
     "coverage": "vitest run --coverage"
   },
   "license": "MIT",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -8,8 +8,8 @@
   ],
   "scripts": {
     "check-types": "tsc --noEmit",
+    "check-biome": "biome check",
     "check-circular": "madge --circular --extensions ts ./src --ts-config ./tsconfig.json",
-    "lint": "biome check",
     "test": "vitest",
     "build": "bunchee --sourcemap --runtime node --target es2022",
     "clean": "del-cli dist tsconfig.tsbuildinfo",

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -2,10 +2,5 @@
   "extends": "@codecompose/typescript-config/library.json",
   "compilerOptions": {
     "outDir": "dist"
-  },
-  "references": [
-    {
-      "path": "../common"
-    }
-  ]
+  }
 }

--- a/services/api/package.json
+++ b/services/api/package.json
@@ -10,9 +10,9 @@
   "scripts": {
     "check-types": "tsc --noEmit",
     "check-circular": "madge --circular --extensions ts ./src --ts-config ./tsconfig.json",
+    "check-biome": "biome check",
     "build": "bunchee --sourcemap --runtime node --target es2022",
     "clean": "del-cli dist isolate tsconfig.tsbuildinfo",
-    "lint": "biome check",
     "deploy": "firebase deploy --project demo-mono-ts --only functions",
     "emulate": "firebase emulators:start --project demo-mono-ts --only functions"
   },

--- a/services/api/tsconfig.json
+++ b/services/api/tsconfig.json
@@ -30,14 +30,5 @@
       "~/*": ["./src/*"]
     }
   },
-  "include": ["./src", "./src/**/*.json"],
-  "exclude": ["./node_modules", "./dist"],
-  "references": [
-    {
-      "path": "../../packages/common"
-    },
-    {
-      "path": "../../packages/core"
-    }
-  ]
+  "include": ["./src", "./src/**/*.json"]
 }

--- a/services/fns/package.json
+++ b/services/fns/package.json
@@ -10,10 +10,10 @@
   ],
   "scripts": {
     "check-types": "tsc --noEmit",
+    "check-biome": "biome check",
     "check-circular": "madge --circular --extensions ts ./src --ts-config ./tsconfig.json",
     "build": "bunchee --sourcemap --runtime node --target es2022",
     "clean": "del-cli dist isolate tsconfig.tsbuildinfo",
-    "lint": "biome check",
     "deploy": "firebase deploy",
     "emulate": "firebase emulators:start --project demo-mono-ts"
   },

--- a/services/fns/tsconfig.json
+++ b/services/fns/tsconfig.json
@@ -1,11 +1,3 @@
 {
-  "extends": "@codecompose/typescript-config/service.json",
-  "references": [
-    {
-      "path": "../../packages/common"
-    },
-    {
-      "path": "../../packages/core"
-    }
-  ]
+  "extends": "@codecompose/typescript-config/service.json"
 }

--- a/turbo.jsonc
+++ b/turbo.jsonc
@@ -23,22 +23,15 @@
       "inputs": ["$TURBO_DEFAULT$", ".env", ".env.demo-mono-ts", ".env.local"]
     },
     "test": {
-      "dependsOn": ["^build"],
       "outputs": [],
       "inputs": ["src/**/*.tsx", "src/**/*.ts", "test/**/*.ts", "test/**/*.tsx"]
     },
     "coverage": {
-      "dependsOn": ["^build"],
       "outputs": ["coverage/**"],
       "inputs": ["src/**/*.tsx", "src/**/*.ts", "test/**/*.ts", "test/**/*.tsx"]
     },
-    "check-types": {
-      "dependsOn": ["^build"]
-    },
+    "check-types": {},
     "check-circular": {},
-    "lint": {
-      "dependsOn": ["^build"]
-    },
     "clean": {
       "cache": false
     },

--- a/turbo.jsonc
+++ b/turbo.jsonc
@@ -33,7 +33,9 @@
     "check-types": {
       "dependsOn": ["^build"]
     },
-    "check-circular": {},
+    "check-circular": {
+      "dependsOn": ["^build"]
+    },
     "clean": {
       "cache": false
     },

--- a/turbo.jsonc
+++ b/turbo.jsonc
@@ -30,7 +30,9 @@
       "outputs": ["coverage/**"],
       "inputs": ["src/**/*.tsx", "src/**/*.ts", "test/**/*.ts", "test/**/*.tsx"]
     },
-    "check-types": {},
+    "check-types": {
+      "dependsOn": ["^build"]
+    },
     "check-circular": {},
     "clean": {
       "cache": false

--- a/turbo.jsonc
+++ b/turbo.jsonc
@@ -23,10 +23,12 @@
       "inputs": ["$TURBO_DEFAULT$", ".env", ".env.demo-mono-ts", ".env.local"]
     },
     "test": {
+      "dependsOn": ["^build"],
       "outputs": [],
       "inputs": ["src/**/*.tsx", "src/**/*.ts", "test/**/*.ts", "test/**/*.tsx"]
     },
     "coverage": {
+      "dependsOn": ["^build"],
       "outputs": ["coverage/**"],
       "inputs": ["src/**/*.tsx", "src/**/*.ts", "test/**/*.ts", "test/**/*.tsx"]
     },


### PR DESCRIPTION
## Overview
This PR refactors the monorepo architecture from TypeScript project references to a bundler-first approach, improving build performance, dependency management, and maintainability.

## Changes

### Architecture Refactor
- Removed TypeScript project references from all packages (`packages/common`, `packages/core`, `apps/web`, `services/api`, `services/fns`)
- Implemented bundler-first approach where shared packages build first, then consumers check types against built artifacts
- Updated Turborepo configuration to ensure proper build dependency ordering (`check-types` now depends on `^build`)

### Build Strategy
- Shared packages (`@repo/common`, `@repo/core`) build first using bundlers (bunchee)
- Consumer packages (`@repo/web`, `@repo/api`, `@repo/fns`) check types against built dist files
- Clear dependency flow: common → core → consumers
- Build artifacts can be cached and reused

### Documentation Updates
- Rewrote README to explain the new architecture (88 lines added)
- Added design philosophy section explaining the bundler-first approach
- Documented package dependencies with visual flow diagram
- Updated article references to note they're outdated and will be rewritten for 2025
- Added build & type checking strategy documentation

### CI/CD Updates
- Updated GitHub Actions to use `check-biome-ci` instead of `check-format` and `lint`
- Streamlined CI matrix for better performance

## Technical Details
- Removed `composite: true` and project reference configurations
- Updated `turbo.jsonc` with proper task dependencies
- Maintained existing bundler configurations (bunchee)
- Preserved all existing functionality

## Impact
- 13 files change